### PR TITLE
send tax rate to stripe

### DIFF
--- a/Classes/Configuration.php
+++ b/Classes/Configuration.php
@@ -10,7 +10,8 @@ class Configuration {
 
     protected int $type = 2278101;
     protected string $stripeApiKey = '';
-    protected string $nonComposerAutoloadPath    = '';
+    protected string $nonComposerAutoloadPath = '';
+    protected bool $handleShippingAsShippingOption = false;
 
     public function __construct() {
 
@@ -18,6 +19,7 @@ class Configuration {
             $configuration = GeneralUtility::makeInstance(ExtensionConfiguration::class)->get('cart_stripe');
             $this->stripeApiKey = $configuration['stripeApiKey'] ?? '';
             $this->nonComposerAutoloadPath = $configuration['nonComposerAutoloadPath'] ?? '';
+            $this->handleShippingAsShippingOption = (bool)($configuration['handleShippingAsShippingOption'] ?? false);
         } catch (\Exception $e) {
         }
     }
@@ -37,5 +39,8 @@ class Configuration {
         return $this->nonComposerAutoloadPath;
     }
 
-
+    public function isHandleShippingAsShippingOption(): bool
+    {
+        return $this->handleShippingAsShippingOption;
+    }
 }

--- a/Readme.md
+++ b/Readme.md
@@ -8,10 +8,10 @@ This extension is currently more a proof of concept and not ready for production
 
 - Install the extension
 - Provide the stripe API key (best is to set it in ENV variables)
+- Configure shipping handling: Enable "Handle shipping fee as shipping option" to use Stripe shipping options (without VAT). By default (disabled), shipping costs are treated as regular line items (with VAT) to match EXT:cart calculations.
 - Copy the TypoScript of the extension + Adopt the payment per country options
 
 ## Todo
 
 - Testing
 - Cancel payment
-- Voucher

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -2,5 +2,8 @@
 # cat=Feature; type=string; label=Stripe API key: Stripe API key
 stripeApiKey =
 
+# cat=Feature; type=boolean; label=Handle shipping fee as shipping option: If enabled, shipping costs are handled as Stripe shipping options (without VAT). If disabled (default), they are treated as regular line items (with VAT) to match EXT:cart calculations. Note: Stripe Tax is not supported by cart_stripe.
+handleShippingAsShippingOption =
+
 # cat=Feature; type=string; label=If not using composer, use this path to load the Stripe library: Path to Stripe library
 nonComposerAutoloadPath =


### PR DESCRIPTION
In order to be able to create better reports in stripe, it is helpful to tell stripe the tax rate of the line items.

Unfortunately it is not possible to also send tax rates of shipping costs as well. Stripe can either calculate the shipping tax rate automatically based on the line items and on the shipping addres country, but that requires the paid Stripe Tax package and requires the buyer to enter his address.

Therefore we introduce an option to just send the shipping costs as line_item with the correct tax rate to have stripe do the same tax calculation as cart does it.
Acutally using Stripe Tax would require another refactoring to not send the tax rates at all and to send the buyer address as well.
New behaviour is default, switch back using extension configuration option handleShippingAsShippingOption