### PR TITLE
send order number to stripe

### DIFF
--- a/Classes/EventListener/Order/Payment/ProviderRedirect.php
+++ b/Classes/EventListener/Order/Payment/ProviderRedirect.php
@@ -121,6 +121,19 @@ class ProviderRedirect
             'customer_email' => $billingAddress ? $billingAddress->getEmail() : '',
             'success_url' => $this->getUrl('success', $this->cartSHash),
             'cancel_url' => $this->getUrl('cancel', $this->cartSHash),
+            'client_reference_id' => $cart->getOrderItem()->getOrderNumber(),
+            // Meta data for the session
+            'metadata' => [
+                'orderNumber' => $cart->getOrderItem()->getOrderNumber(),
+            ],
+
+            // Information for the Payment Intent
+            'payment_intent_data' => [
+                'metadata' => [
+                    'orderNumber' => $cart->getOrderItem()->getOrderNumber(),
+                ],
+                'description' => LocalizationUtility::translate('LLL:EXT:cart/Resources/Private/Language/locallang.xlf:tx_cart_domain_model_order_item.order_number', 'cart') . ' #' . $cart->getOrderItem()->getOrderNumber(),
+            ],
         ];
 
         if( $this->cart->getCoupons()){


### PR DESCRIPTION
Send order number to Stripe checkout sessions and payment intents for better order tracking and reconciliation.

  - Add order number to Stripe session client_reference_id and metadata
  - Include order number in payment intent metadata and description
  - add order number label with localized translation